### PR TITLE
Update backend CI to use yarn

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,0 +1,55 @@
+name: PR (CI) Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      NX_TODO_BACKEND_HOST: http://localhost:8080
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Checkout Web Repo
+        uses: actions/checkout@v4
+        with:
+          repository: nm123github/todos-frontend
+          ref: main
+          ssh-key: ${{ secrets.WEB_REPO_DEPLOY_KEY }}
+          path: web-repo
+
+      - name: Set up Docker Compose
+        run: |
+          docker compose -f docker-compose.yml up -d
+
+      - name: Corepack Enable
+        run: |
+          corepack enable && corepack prepare yarn@4.5.3 --activate
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 23.5.0
+          cache: 'yarn'
+
+      - name: Install Dependencies
+        run: |
+          yarn install --immutable
+        working-directory: web-repo
+
+      - name: Install Playwright
+        run: |
+          yarn playwright install --with-deps chromium
+        working-directory: web-repo
+
+      - name: Run Playwright Tests
+        run: |
+          yarn e2e
+        working-directory: web-repo
+
+      - name: Clean Up
+        run: |
+          docker compose -f docker-compose.yml down

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           node-version: 23.5.0
           cache: 'yarn'
+          cache-dependency-path: web-repo/yarn.lock
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Set up Docker Compose
         run: |
           docker compose -f docker-compose.yml up -d
+          docker compose -f web-repo/docker-compose.yml up -d
 
       - name: Corepack Enable
         run: |
@@ -54,3 +55,4 @@ jobs:
       - name: Clean Up
         run: |
           docker compose -f docker-compose.yml down
+          docker compose -f web-repo/docker-compose.yml down


### PR DESCRIPTION
## Summary
- adapt the backend PR workflow to match the frontend setup
- start the backend with docker compose
- use yarn 4.5.3 and Node 23.5.0 to run Playwright e2e tests

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_683fa6740128832184c75d10fefb9bfa